### PR TITLE
Added conversion for custom field names and coordinate systems

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -1,7 +1,11 @@
 module.exports = {
-  host: 'localhost',
-  user: 'yourusername',
-  password: 'yourpassword',
-  port: 5432,
-  database: 'yourdatabase'
+  database: {
+    host: 'localhost',
+    user: 'yourusername',
+    password: 'yourpassword',
+    port: 5432,
+    database: 'yourdatabase'
+  },
+  dataCoordinateSystem: 26915,
+  geomFieldNames: ['pt_geom', 'the_geom']
 }


### PR DESCRIPTION
Hi again. For your consideration...

This allows postgis-preview to work against databases that do not use 'geom' as the field name for the geometry or that do not use lat/lon (4326) for the coordinate system. 

A summary of the changes:
- **config.json** - minor changes to the structure of the data and two fields added. The fields are 1) dataCoordinateSystem - the coordinate system of the table date, and 2) geomFieldNames - an array of field names that can be converted to 'geom'
- **dataCoordinateSystem** could be boolean, but perhaps it would be useful at some point to know the native coordinate system?
- I used an array for **geomFieldNames** because some of us are lucky enough to have inherited systems that use multiple names for the geometry field.
- **server.js** - the DB config looks for config['database'] instead of just config and string manipulation is used to convert custom field names (_SELECT some_name_ becomes _SELECT some_name as geom_) or convert data to 4326 using [ST_Transform](http://postgis.net/docs/ST_Transform.html) (_SELECT ST_Transform(the_geom, 4326) as geom_)

The biggest advantage is that end users can query using their native field names and do not need to worry about converting to 4326. For example:

A user can use:
```
SELECT pt_geom, address, count(*) FROM table...
```
instead of having to type the following:

```
SELECT ST_Transform(pt_geom, 4326) as geom, address, count(*) FROM table...
```

It's a very minor and subtle difference, but I figured it might be useful for others who are stuck with legacy systems and want to provide this to end users who may find coordinate systems etc confusing.

This was just a quick fix I put up at work today and I'm relatively new to NodeJS so suspect there is probably a better way of doing this!

Thanks.
