### PR TITLE
Allow for queries with no geom

### DIFF
--- a/dbgeo-modified.js
+++ b/dbgeo-modified.js
@@ -55,7 +55,9 @@
         async.each(params.data, function(row, geomCallback) {
 
           var parsedRow = { "type": "Feature" };
-          if (params.geometryType === "wkt") {
+          if (!row[params.geometryColumn]) {
+            parsedRow.geometry = null;
+          } else if (params.geometryType === "wkt") {
             parsedRow.geometry = wellknown(row[params.geometryColumn]);
           } else if (params.geometryType === "wkb") {
             var wkbBuffer = new Buffer(row[params.geometryColumn], 'hex');

--- a/dbgeo-modified.js
+++ b/dbgeo-modified.js
@@ -69,7 +69,7 @@
             parsedRow.geometry = wellknown(point);
           }
 
-          if (Object.keys(row).length > 1) {
+          if (Object.keys(row).length > 0) {
             parsedRow.properties = {};
             async.each(Object.keys(row), function(property, propCallback) {
               if (property !== params.geometryColumn) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -48,7 +48,16 @@ attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreet
         //convert topojson coming over the wire to geojson using mapbox omnivore
         var features = omnivore.topojson.parse(data); //should this return a featureCollection?  Right now it's just an array of features.
         var featureCount = data.objects.output.geometries.length;
-        addLayer( features ); //draw the map layer
+        var geoFeatures = features.filter(function(feature) {
+          return feature.geometry;
+        });
+        if (geoFeatures.length) {
+          addLayer( geoFeatures ); //draw the map layer
+        } else {
+          // There is no map to display, so switch to the data view
+          $('#map').hide();
+          $('#table').show();
+        }
         buildTable( features ); //build the table
         $('#notifications').removeClass().addClass('alert alert-success');
         $('#notifications').text(featureCount + ' features returned.');

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -51,16 +51,21 @@ attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreet
         var geoFeatures = features.filter(function(feature) {
           return feature.geometry;
         });
+        $('#notifications').removeClass().addClass('alert alert-success');
         if (geoFeatures.length) {
           addLayer( geoFeatures ); //draw the map layer
+          $('#notifications').text(featureCount + ' features returned.');
         } else {
           // There is no map to display, so switch to the data view
-          $('#map').hide();
-          $('#table').show();
+          $('#notifications').html(featureCount + ' features returned.<br/>No geometries returned, see the <a href="#" class="data-view">data view</a> for results.');
+          //toggle map and data view
+          $('a.data-view').click(function(){
+            $('#map').hide();
+            $('#table').show();
+          });
+
         }
         buildTable( features ); //build the table
-        $('#notifications').removeClass().addClass('alert alert-success');
-        $('#notifications').text(featureCount + ' features returned.');
       }
 
     })


### PR DESCRIPTION
This should fix this issue: https://github.com/NYCPlanning/postgis-preview/issues/32

I allowed the dbGeo function to work without a "geom" column, and I allowed it to pass data through if there are any rows (formerly, it required a geometry column).

The script.js was changed to filter out non-geom containing rows and only pass those to the map. All rows are still passed to the data table.

A message will appear on the right stating that no geometry rows have been returned.

<img width="288" alt="screen shot 2016-05-24 at 12 16 44 pm" src="https://cloud.githubusercontent.com/assets/98192/15511488/bea50ba6-21a9-11e6-8ef9-0fea95e60fad.png">