### PR TITLE
Fix typos and capitalization

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -1,12 +1,12 @@
 #PostGIS Preview
-A lightweight node api and frontend for quicky previewing PostGIS queries. _Pull Requests Welcomed!_  Take a look at the [open issues](https://github.com/chriswhong/postgis-preview/issues)
+A lightweight node api and frontend for quickly previewing PostGIS queries. _Pull Requests Welcomed!_  Take a look at the [open issues](https://github.com/chriswhong/postgis-preview/issues)
 
 ![preview](https://cloud.githubusercontent.com/assets/1833820/14897977/7e8088cc-0d52-11e6-9c0e-b56f3b2af954.gif)
 
 ###Why
 Our team at the NYC Department of City Planning needed to be able to test out PostGIS queries in a local environment and iterate quickly.  CartoDB provides this functionality, giving users a SQL pane and a map view to quickly see the geometries returned from the database (This UI and SQL preview workflow are inspired by the CartoDB editor)
 
-When asking on twitter if anyone had solutions to this problem, responses included:
+When asking on Twitter if anyone had solutions to this problem, responses included:
   - Run queries in pgadmin and use `ST_asGeoJson()`, copy and paste the geojson into [geojson.io](http://www.geojson.io)
   - Use [QGIS](http://www.qgis.org/en/site/) dbmanager.  This works, but requires a few clicks once the data are returned to add them to the map.
   - Use various command line tools that show previews in the terminal or send the results to geojson.io programmatically.
@@ -14,7 +14,7 @@ When asking on twitter if anyone had solutions to this problem, responses includ
 ###How it works
 The express.js app has a single endpoint:  `/sql` that is passed a SQL query `q` as a url parameter.  That query is passed to PostGIS using the _pg-promise_ module.  The resulting data are transformed into topojson using a modified _dbgeo_ module (modified to include parsing WKB using the _WKX_ module), and the response is sent to the frontend.
 
-The frontend is a simple bootstrap layout with a leaflet map, cartodb basemaps, a table, and a SQL pane.  The topojson from the API is parsed using _omnivore_ by Mapbox, and added to the map as an L.geoJson layer with generic styling.
+The frontend is a simple Bootstrap layout with a Leaflet map, CartoDB basemaps, a table, and a SQL pane.  The TopoJSON from the API is parsed using _omnivore_ by Mapbox, and added to the map as an L.geoJson layer with generic styling.
 
 ### How to Use
 


### PR DESCRIPTION
Just some minor cleanup here. This started as fixing a typo and grew into changing capitalization on some of the proper names sprinkled throughout the Readme (eg cartodb -> CartoDB)