### PR TITLE
Addresses #31

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -103,3 +103,8 @@ body {
 #download {
   display: none;
 }
+
+.leaflet-popup-content {
+  max-height: 50vh;
+  overflow-y: scroll;
+}


### PR DESCRIPTION
Adds some simple CSS which computes max-height of infowindow as the vertical height of the screen. Enables scrolling if contents exceed that max-height.